### PR TITLE
Migrated to new repo with the original base as it's master.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG FIVEM_NUM=3184
 ARG FIVEM_VER=3184-6123f9196eb8cd2a987a1dd7ff7b36907a787962
-ARG DATA_VER=dd38bd01923a0595ecccef8026f1310304d7b0e3
+ARG DATA_VER=master
 
 FROM spritsail/alpine:3.12 as builder
 
@@ -42,6 +42,11 @@ LABEL maintainer="Spritsail <fivem@spritsail.io>" \
       io.spritsail.version.fivem_data=${DATA_VER}
 
 COPY --from=builder /output/ /
+
+# Setting the timezone so that it can be used with SimpleSync.
+RUN apk add tzdata
+RUN cp /usr/share/zoneinfo/America/New_York /etc/localtime
+RUN echo "America/New_York" >  /etc/timezone
 
 WORKDIR /config
 EXPOSE 30120


### PR DESCRIPTION
This release includes:

1. Updated to latest FiveM Linux version of 3184.
1. Updated to always pull resources from the master branch.
1. Updated to include ability to set the timezone in the docker file. This allows the use of scripts such as simplesync which can set the in game time based on a specific timezone.